### PR TITLE
[TMLY-20] Swagger - OpenAPI 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,9 @@ dependencies {
     implementation 'org.flywaydb:flyway-core:8.5.13'
     implementation 'org.flywaydb:flyway-mysql:8.5.13'
 
+    // SPRING DOCS
+    implementation 'org.springdoc:springdoc-openapi-ui:1.6.9'
+
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/src/main/java/com/midas/ticket/common/ApiError.java
+++ b/src/main/java/com/midas/ticket/common/ApiError.java
@@ -5,9 +5,14 @@ import java.time.LocalDateTime;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public class ApiError {
 
+	@Schema(description = "오류 발생 시간", required = true)
 	private final LocalDateTime timestamp;
+
+	@Schema(description = "오류 메시지", required = true)
 	private final String message;
 
 	public ApiError(LocalDateTime timestamp, String message) {

--- a/src/main/java/com/midas/ticket/common/ApiResponse.java
+++ b/src/main/java/com/midas/ticket/common/ApiResponse.java
@@ -5,9 +5,17 @@ import java.time.LocalDateTime;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public class ApiResponse<T> {
+
+	@Schema(description = "API 요청 처리 결과", required = true)
 	private final boolean success;
+
+	@Schema(description = "success가 true라면, API 요청 처리 응답값")
 	private final T response;
+
+	@Schema(description = "success가 false라면, API 요청 처리 응답값")
 	private final ApiError error;
 
 	public ApiResponse(boolean success, T response, ApiError error) {

--- a/src/main/java/com/midas/ticket/user/dto/JoinRequest.java
+++ b/src/main/java/com/midas/ticket/user/dto/JoinRequest.java
@@ -3,9 +3,17 @@ package com.midas.ticket.user.dto;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public class JoinRequest {
+
+	@Schema(description = "로그인 이메일", required = true)
 	private String principal;
+
+	@Schema(description = "로그인 비밀번호", required = true)
 	private String credentials;
+
+	@Schema(description = "이름", required = true)
 	private String name;
 
 	public JoinRequest() {

--- a/src/main/java/com/midas/ticket/user/dto/MemberResponse.java
+++ b/src/main/java/com/midas/ticket/user/dto/MemberResponse.java
@@ -3,8 +3,14 @@ package com.midas.ticket.user.dto;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public class MemberResponse {
+
+	@Schema(description = "사용자 ID", required = true)
 	private final Long id;
+
+	@Schema(description = "사용자 이름", required = true)
 	private final String name;
 
 	public MemberResponse(Long id, String name) {

--- a/src/main/java/com/midas/ticket/user/web/MemberRestController.java
+++ b/src/main/java/com/midas/ticket/user/web/MemberRestController.java
@@ -14,6 +14,10 @@ import com.midas.ticket.user.dto.JoinRequest;
 import com.midas.ticket.user.dto.MemberResponse;
 import com.midas.ticket.user.service.MemberService;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "회원 API")
 @RestController
 @RequestMapping("/api/v1/members")
 public class MemberRestController {
@@ -24,6 +28,8 @@ public class MemberRestController {
 		this.memberService = memberService;
 	}
 
+
+	@Operation(summary = "회원 가입")
 	@PostMapping
 	@ResponseStatus(HttpStatus.CREATED)
 	public ApiResponse<MemberResponse> join(@RequestBody JoinRequest request) {


### PR DESCRIPTION
## ✅ 작업 단위

### [[TMLY-20] feat: Swagger - OpenAPI 적용](https://github.com/midasWorld/ticket-service/commit/1945e0bca6b4e6d079202f6a6ec482e03dca4c45)
- DTO 일괄 `@Schema` 어노테이션 적용 (ApiResponse, ApiError, JoinRequest, MemberResponse)
- 회원 컨트롤러에도 스웨거 어노테이션 적용 완료

### 접속 주소
- swagger-ui : http://localhost:8080/swagger-ui/index.html
- api-docs : http://localhost:8080/v3/api-docs/

[TMLY-20]: https://midasworld.atlassian.net/browse/TMLY-20?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ