### PR TITLE
[TMLY-12] 사용자 로그인 구현

### DIFF
--- a/src/main/java/com/midas/ticket/user/domain/Member.java
+++ b/src/main/java/com/midas/ticket/user/domain/Member.java
@@ -48,6 +48,13 @@ public class Member {
 		this.name = name;
 	}
 
+	//== 비지니스 로직 ==//
+	public void login(String password) {
+		if (!password.equals(this.password)) {
+			throw new IllegalArgumentException("Bad credential");
+		}
+	}
+
 	public Long getId() {
 		return id;
 	}

--- a/src/main/java/com/midas/ticket/user/dto/LoginRequest.java
+++ b/src/main/java/com/midas/ticket/user/dto/LoginRequest.java
@@ -1,0 +1,39 @@
+package com.midas.ticket.user.dto;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public class LoginRequest {
+
+	@Schema(description = "로그인 이메일", required = true)
+	private String principal;
+
+	@Schema(description = "로그인 비밀번호", required = true)
+	private String credentials;
+
+	public LoginRequest() {
+	}
+
+	public LoginRequest(String principal, String credentials) {
+		this.principal = principal;
+		this.credentials = credentials;
+	}
+
+	public String getPrincipal() {
+		return principal;
+	}
+
+	public String getCredentials() {
+		return credentials;
+	}
+
+	@Override
+	public String toString() {
+		return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+			.append("principal", principal)
+			.append("credentials", credentials)
+			.toString();
+	}
+}

--- a/src/main/java/com/midas/ticket/user/repository/MemberRepository.java
+++ b/src/main/java/com/midas/ticket/user/repository/MemberRepository.java
@@ -1,8 +1,12 @@
 package com.midas.ticket.user.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.midas.ticket.user.domain.Member;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+	Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/midas/ticket/user/service/MemberService.java
+++ b/src/main/java/com/midas/ticket/user/service/MemberService.java
@@ -21,4 +21,12 @@ public class MemberService {
 
 		return new MemberResponse(savedMember.getId(), name);
 	}
+
+	public MemberResponse login(String principal, String credentials) {
+
+		Member member = memberRepository.findByEmail(principal)
+			.orElseThrow(() -> new IllegalArgumentException("Could not found User with email=" + principal));
+		member.login(credentials);
+		return new MemberResponse(member.getId(), member.getName());
+	}
 }

--- a/src/main/java/com/midas/ticket/user/web/MemberRestController.java
+++ b/src/main/java/com/midas/ticket/user/web/MemberRestController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.midas.ticket.common.ApiResponse;
 import com.midas.ticket.user.dto.JoinRequest;
+import com.midas.ticket.user.dto.LoginRequest;
 import com.midas.ticket.user.dto.MemberResponse;
 import com.midas.ticket.user.service.MemberService;
 
@@ -34,6 +35,15 @@ public class MemberRestController {
 	@ResponseStatus(HttpStatus.CREATED)
 	public ApiResponse<MemberResponse> join(@RequestBody JoinRequest request) {
 		MemberResponse member = memberService.join(request.getPrincipal(), request.getCredentials(), request.getName());
+
+		return OK(member);
+	}
+
+	@Operation(summary = "로그인")
+	@PostMapping("/login")
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResponse<MemberResponse> login(@RequestBody LoginRequest request) {
+		MemberResponse member = memberService.login(request.getPrincipal(), request.getCredentials());
 
 		return OK(member);
 	}

--- a/src/test/java/com/midas/ticket/user/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/midas/ticket/user/repository/MemberRepositoryTest.java
@@ -3,6 +3,7 @@ package com.midas.ticket.user.repository;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.samePropertyValuesAs;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Optional;
@@ -32,6 +33,20 @@ class MemberRepositoryTest {
 		Member savedMember = memberRepository.save(newMember);
 
 		assertThat(savedMember.getId(), notNullValue());
+	}
+
+	@Test
+	@DisplayName("회원 이메일로 조회된다.")
+	void test_findByEmail() {
+		// given
+		Member savedMember = memberRepository.save(newMember);
+
+		// when
+		Optional<Member> foundMember = memberRepository.findByEmail(savedMember.getEmail());
+
+		// then
+		assertThat(foundMember.isEmpty(), is(false));
+		assertThat(foundMember.get(), samePropertyValuesAs(savedMember));
 	}
 
 	@Test

--- a/src/test/java/com/midas/ticket/user/service/MemberServiceTest.java
+++ b/src/test/java/com/midas/ticket/user/service/MemberServiceTest.java
@@ -1,10 +1,14 @@
 package com.midas.ticket.user.service;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.samePropertyValuesAs;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -26,25 +30,67 @@ class MemberServiceTest {
 	@InjectMocks
 	MemberService memberService;
 
+	private static final Long ID = 1L;
+	private static final String EMAIL = "test77@naver.com";
+	private static final String PASSWORD = "1234";
+	private static final String NAME = "test77";
+
 	@Test
 	@DisplayName("사용자가 회원가입 한다.")
 	void test_join() {
-		final Long id = 1L;
-		final String email = "test77@naver.com";
-		final String password = "1234";
-		final String name = "test77";
-
-		final Member member = new Member(id, email, password, name);
-		final MemberResponse response = new MemberResponse(id, name);
+		final Member member = new Member(ID, EMAIL, PASSWORD, NAME);
+		final MemberResponse response = new MemberResponse(ID, NAME);
 
 		given(memberRepository.save(any(Member.class))).willReturn(member);
 
 		// when
-		MemberResponse joinedMember = memberService.join(email, password, name);
+		MemberResponse joinedMember = memberService.join(EMAIL, PASSWORD, NAME);
 
 		// then
 		verify(memberRepository).save(any(Member.class));
 
 		assertThat(joinedMember, samePropertyValuesAs(response));
+	}
+
+	@Test
+	@DisplayName("사용자가 로그인 한다.")
+	void test_login() {
+		final Member member = new Member(ID, EMAIL, PASSWORD, NAME);
+		final MemberResponse response = new MemberResponse(ID, NAME);
+
+		given(memberRepository.findByEmail(any(String.class))).willReturn(Optional.of(member));
+
+		// when
+		MemberResponse loginedMember = memberService.login(EMAIL, PASSWORD);
+
+		// then
+		verify(memberRepository).findByEmail(any(String.class));
+
+		assertThat(loginedMember, samePropertyValuesAs(response));
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 이메일로 로그인 실패한다.")
+	void test_fail_notExistsByEmail() {
+		final String notExistsEmail = "wrong@gmail.com";
+
+		when(memberRepository.findByEmail(notExistsEmail)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> {
+			memberService.login(notExistsEmail, PASSWORD);
+		}).isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	@DisplayName("일치하지 않는 비밀번호로 로그인 실패한다.")
+	void test_fail_wrongPassword() {
+		final String wrongPassword = "wrong1234";
+		final Member member = new Member(ID, EMAIL, PASSWORD, NAME);
+
+		given(memberRepository.findByEmail(EMAIL)).willReturn(Optional.of(member));
+
+		assertThatThrownBy(() -> {
+			memberService.login(EMAIL, wrongPassword);
+		}).isInstanceOf(IllegalArgumentException.class);
 	}
 }

--- a/src/test/java/com/midas/ticket/user/web/MemberRestControllerTest.java
+++ b/src/test/java/com/midas/ticket/user/web/MemberRestControllerTest.java
@@ -19,6 +19,7 @@ import org.springframework.test.web.servlet.ResultActions;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.midas.ticket.user.dto.JoinRequest;
+import com.midas.ticket.user.dto.LoginRequest;
 import com.midas.ticket.user.dto.MemberResponse;
 import com.midas.ticket.user.service.MemberService;
 
@@ -35,15 +36,16 @@ class MemberRestControllerTest {
 	@MockBean
 	private MemberService memberService;
 
+	private static final Long ID = 1L;
+	private static final String EMAIL = "test77@gmail.com";
+	private static final String PASSWORD = "1234";
+	private static final String NAME = "test77";
+
 	@Test
 	@DisplayName("사용자가 회원가입 한다.")
 	void test_join() throws Exception {
-		final String email = "test77@gmail.com";
-		final String password = "1234";
-		final String name = "test77";
-
-		JoinRequest joinRequest = new JoinRequest(email, password, name);
-		MemberResponse memberResponse = new MemberResponse(1L, name);
+		JoinRequest joinRequest = new JoinRequest(EMAIL, PASSWORD, NAME);
+		MemberResponse memberResponse = new MemberResponse(ID, NAME);
 
 		String request = objectMapper.writeValueAsString(joinRequest);
 		String response = objectMapper.writeValueAsString(OK(memberResponse));
@@ -61,6 +63,31 @@ class MemberRestControllerTest {
 
 		perform
 			.andExpect(status().isCreated())
+			.andExpect(content().string(response));
+	}
+
+	@Test
+	@DisplayName("사용자가 로그인 한다.")
+	void test_login() throws Exception {
+		LoginRequest loginRequest = new LoginRequest(EMAIL, PASSWORD);
+		MemberResponse memberResponse = new MemberResponse(ID, NAME);
+
+		String request = objectMapper.writeValueAsString(loginRequest);
+		String response = objectMapper.writeValueAsString(OK(memberResponse));
+
+		given(memberService.login(anyString(), anyString())).willReturn(memberResponse);
+
+		// when
+		ResultActions perform = mockMvc.perform(post(API_URL + "/login")
+			.content(request)
+			.contentType(APPLICATION_JSON)
+		);
+
+		// then
+		verify(memberService).login(anyString(), anyString());
+
+		perform
+			.andExpect(status().isOk())
 			.andExpect(content().string(response));
 	}
 }


### PR DESCRIPTION
## ✅ 작업 단위

### [[TMLY-12] feat: 사용자 로그인 구현](https://github.com/midasWorld/ticket-service/commit/1a03f18edda80affc1a37748c7bb0fe768e3e094)
- Member - login 메서드 생성(추후 매개변수로 passwordEncoder 추가 예정)
- MemberRepository - findByEmail 메서드 구현 (For 로그인)
- 서비스, 컨트롤러에서 로그인 메서드 추가

### [[TMLY-12] test: 사용자 로그인 테스트 작성](https://github.com/midasWorld/ticket-service/commit/d7844a873ed3bcf4f114f7de5e5beaa64587e75b)
- MemberRepositoryTest - findByEmail 메서드 테스트 추가
- MemberServiceTest - 로그인, 존재하지 않는 이메일, 일치하지 않는 비밀번호 테스트 추가
- MemberRestControllerTest  - 로그인 테스트 추가

[TMLY-12]: https://midasworld.atlassian.net/browse/TMLY-12?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TMLY-12]: https://midasworld.atlassian.net/browse/TMLY-12?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ